### PR TITLE
Writing to the 4 last bytes in a page causes "out-of-bounds" writes to the intended flash range, and potential over-writing of other data stored in flash

### DIFF
--- a/src/NVSOnboard.cpp
+++ b/src/NVSOnboard.cpp
@@ -461,7 +461,7 @@ size_t NVSOnboard::pagesSize(){
 		}
 		 it++;
 	}
-	size = 2 * sizeof(uint32_t ) + indexSize + dataSize;
+	size = sizeof(nvs_header_t) + indexSize + dataSize;
 	pagesSize = (size / 256) * 256;
 	if (size > (pagesSize)){
 		pagesSize += 256;


### PR DESCRIPTION
Writing to the 4 last bytes in a page (without going over the current page size, which will cause it to be extended it with another 256 bytes) causes "out-of-bounds" writing to the "allocated" range in flash, and potential over-writing of other data stored in flash.

Cause of issue:
Size of NVS header is 12 bytes, not 8. Hence, the "allocated" range in flash is 4 bytes short of what is needed/used. 

Fix: 
Modified header-size addend to "sizeof(nvs_header_t)" in the calculation of the page size (as that seems more readable than "3*sizeof(uint32_t)")